### PR TITLE
feat: case-insensitive prefix/suffix regexes

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -97,9 +97,9 @@ export const escapeRegExp = (text: string): string => text.replace(/[.*+?^${}()|
 
 export const getRegExp = (value: string): RegExp => new RegExp(escapeRegExp(value));
 
-export const getPrefixRegExp = (value: string): RegExp => new RegExp('^' + escapeRegExp(value));
+export const getPrefixRegExp = (value: string): RegExp => new RegExp('^' + escapeRegExp(value), 'i');
 
-export const getSuffixRegExp = (value: string): RegExp => new RegExp(escapeRegExp(value) + '$');
+export const getSuffixRegExp = (value: string): RegExp => new RegExp(escapeRegExp(value) + '$', 'i');
 
 export const getBoolValue = (input: string): boolean => !['false', '0', '', 'no', 'n'].includes(input.trim().toLowerCase());
 


### PR DESCRIPTION
## Description: 概要
Make the `getPrefixRegExp` and `getSuffixRegExp` functions case insensitive. 

See https://github.com/technote-space/get-diff-action/issues/101#issuecomment-670693032

## Changes: 変更内容

See diff. 

## Expected Impact: 影響範囲
Assumes that everyone always wants case-INsensitive prefix and suffix regexes. 

## Operating Requirements: 動作要件
N/A

## Additional context: 補足
See https://github.com/technote-space/get-diff-action/issues/101
