### PR TITLE
release: v5.3.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@actions/core": "^1.10.0",
     "@actions/github": "^5.1.1",
-    "@technote-space/github-action-log-helper": "^0.2.10",
+    "@technote-space/github-action-log-helper": "^0.2.11",
     "shell-escape": "^0.2.0",
     "sprintf-js": "^1.1.2"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@technote-space/github-action-helper",
-  "version": "5.3.12",
+  "version": "5.3.13",
   "description": "Helper for GitHub Action.",
   "keywords": [
     "github",

--- a/yarn.lock
+++ b/yarn.lock
@@ -525,10 +525,10 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/tsconfig/-/tsconfig-3.0.1.tgz#e2eaebda42aa7a755b11bdfbea847446652e1ac4"
   integrity sha512-0/gtPNTY3++0J2BZM5nHHULg0BIMw886gqdn8vWN+Av6bgF5ZU2qIcHubAn+Z9KNvJhO8WFE+9kDOU3n6OcKtA==
 
-"@technote-space/github-action-log-helper@^0.2.10":
-  version "0.2.10"
-  resolved "https://registry.yarnpkg.com/@technote-space/github-action-log-helper/-/github-action-log-helper-0.2.10.tgz#613af35526d79ca0040894c14c1bb32070ae2c87"
-  integrity sha512-JTCdLDNqAijD8kXkRgVUIGX7lvxUiP+x6+jfNdpzEet2HhMovnoZkOxCdnV356SzxFDraG+sUXIAXtZFxL0zFA==
+"@technote-space/github-action-log-helper@^0.2.11":
+  version "0.2.11"
+  resolved "https://registry.yarnpkg.com/@technote-space/github-action-log-helper/-/github-action-log-helper-0.2.11.tgz#cb017cef104edea9ace70d442423c8bd2cffab5c"
+  integrity sha512-tyQ+plryKHPGoBs64Ka6g0xwxBzBqt68Rd41UdPA3L1j0U5fPNRtE/zg1Bwgpi+kHwi+1ZPdHWxZYdRy/6iw+g==
   dependencies:
     "@actions/core" "^1.10.0"
     sprintf-js "^1.1.2"


### PR DESCRIPTION
<!-- START pr-commits   please keep comment here to allow auto update -->
## Changes


* chore: update npm dependencies (404653adba1f81a494504f221a7a41910368e31d)

<!-- END pr-commits   please keep comment here to allow auto update -->

## Base PullRequest

default branch (https://github.com/technote-space/github-action-helper/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/build/src/bin
```



</details>
<details>
<summary><em>cli.js -u --packageFile package.json</em></summary>

```Shell
Using yarn
Upgrading /home/runner/work/github-action-helper/github-action-helper/package.json

 @technote-space/github-action-log-helper  ^0.2.10  →  ^0.2.11

Run yarn install to install new versions.
```



</details>
<details>
<summary><em>yarn install</em></summary>

```Shell
yarn install v1.22.19
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved lockfile.
$ [ -n "$CI" ] || [ ! -f node_modules/.bin/husky ] || husky install
Done in 20.23s.
```



</details>
<details>
<summary><em>yarn upgrade</em></summary>

```Shell
yarn upgrade v1.22.19
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Rebuilding all packages...
success Saved lockfile.
success Saved 336 new dependencies.
info Direct dependencies
├─ @commitlint/cli@17.4.4
├─ @commitlint/config-conventional@17.4.4
├─ @rollup/plugin-typescript@11.0.0
├─ @sindresorhus/tsconfig@3.0.1
├─ @technote-space/github-action-log-helper@0.2.11
├─ @technote-space/github-action-test-helper@0.11.3
├─ @types/node@18.14.0
├─ @types/shell-escape@0.2.1
├─ @typescript-eslint/eslint-plugin@5.53.0
├─ @typescript-eslint/parser@5.53.0
├─ @vitest/coverage-c8@0.28.5
├─ eslint-plugin-import@2.27.5
├─ eslint@8.34.0
├─ husky@8.0.3
├─ lint-staged@13.1.2
├─ nock@13.3.0
├─ rollup@3.17.2
├─ shell-escape@0.2.0
└─ typescript@4.9.5
info All dependencies
├─ @babel/code-frame@7.18.6
├─ @babel/helper-validator-identifier@7.19.1
├─ @babel/highlight@7.18.6
├─ @bcoe/v8-coverage@0.2.3
├─ @commitlint/cli@17.4.4
├─ @commitlint/config-conventional@17.4.4
├─ @commitlint/ensure@17.4.4
├─ @commitlint/execute-rule@17.4.0
├─ @commitlint/format@17.4.4
├─ @commitlint/is-ignored@17.4.4
├─ @commitlint/lint@17.4.4
├─ @commitlint/load@17.4.4
├─ @commitlint/message@17.4.2
├─ @commitlint/parse@17.4.4
├─ @commitlint/read@17.4.4
├─ @commitlint/resolve-extends@17.4.4
├─ @commitlint/rules@17.4.4
├─ @commitlint/to-lines@17.4.0
├─ @commitlint/top-level@17.4.0
├─ @cspotcode/source-map-support@0.8.1
├─ @esbuild/linux-x64@0.16.17
├─ @eslint/eslintrc@1.4.1
├─ @humanwhocodes/config-array@0.11.8
├─ @humanwhocodes/module-importer@1.0.1
├─ @humanwhocodes/object-schema@1.2.1
├─ @istanbuljs/schema@0.1.3
├─ @jridgewell/resolve-uri@3.1.0
├─ @jridgewell/sourcemap-codec@1.4.14
├─ @jridgewell/trace-mapping@0.3.17
├─ @nodelib/fs.scandir@2.1.5
├─ @nodelib/fs.stat@2.0.5
├─ @nodelib/fs.walk@1.2.8
├─ @octokit/auth-token@2.5.0
├─ @octokit/core@3.6.0
├─ @octokit/endpoint@6.0.12
├─ @octokit/graphql@4.8.0
├─ @octokit/openapi-types@12.11.0
├─ @octokit/plugin-paginate-rest@2.21.3
├─ @octokit/plugin-rest-endpoint-methods@5.16.2
├─ @octokit/request-error@2.1.0
├─ @octokit/request@5.6.3
├─ @rollup/plugin-typescript@11.0.0
├─ @rollup/pluginutils@5.0.2
├─ @sindresorhus/tsconfig@3.0.1
├─ @technote-space/github-action-log-helper@0.2.11
├─ @technote-space/github-action-test-helper@0.11.3
├─ @tsconfig/node10@1.0.9
├─ @tsconfig/node12@1.0.11
├─ @tsconfig/node14@1.0.3
├─ @tsconfig/node16@1.0.3
├─ @types/chai-subset@1.3.3
├─ @types/chai@4.3.4
├─ @types/estree@1.0.0
├─ @types/istanbul-lib-coverage@2.0.4
├─ @types/json-schema@7.0.11
├─ @types/json5@0.0.29
├─ @types/minimist@1.2.2
├─ @types/node@18.14.0
├─ @types/normalize-package-data@2.4.1
├─ @types/semver@7.3.13
├─ @types/shell-escape@0.2.1
├─ @typescript-eslint/eslint-plugin@5.53.0
├─ @typescript-eslint/parser@5.53.0
├─ @typescript-eslint/type-utils@5.53.0
├─ @vitest/coverage-c8@0.28.5
├─ @vitest/expect@0.28.5
├─ @vitest/runner@0.28.5
├─ acorn-jsx@5.3.2
├─ acorn-walk@8.2.0
├─ acorn@8.8.2
├─ aggregate-error@3.1.0
├─ ajv@6.12.6
├─ ansi-escapes@4.3.2
├─ arg@4.1.3
├─ argparse@2.0.1
├─ array-ify@1.0.0
├─ array-includes@3.1.6
├─ array-union@2.1.0
├─ array.prototype.flat@1.3.1
├─ array.prototype.flatmap@1.3.1
├─ arrify@1.0.1
├─ assertion-error@1.1.0
├─ balanced-match@1.0.2
├─ before-after-hook@2.2.3
├─ brace-expansion@1.1.11
├─ braces@3.0.2
├─ buffer-from@1.1.2
├─ c8@7.13.0
├─ callsites@3.1.0
├─ camelcase-keys@6.2.2
├─ camelcase@5.3.1
├─ chalk@4.1.2
├─ check-error@1.0.2
├─ clean-stack@2.2.0
├─ cli-cursor@3.1.0
├─ cliui@8.0.1
├─ color-convert@2.0.1
├─ color-name@1.1.4
├─ commander@9.5.0
├─ concat-map@0.0.1
├─ conventional-changelog-angular@5.0.13
├─ conventional-changelog-conventionalcommits@5.0.0
├─ conventional-commits-parser@3.2.4
├─ convert-source-map@1.9.0
├─ cosmiconfig-typescript-loader@4.3.0
├─ cosmiconfig@8.0.0
├─ create-require@1.1.1
├─ dargs@7.0.0
├─ debug@4.3.4
├─ decamelize-keys@1.1.1
├─ decamelize@1.2.0
├─ deep-eql@4.1.3
├─ deep-is@0.1.4
├─ deprecation@2.3.1
├─ diff@5.1.0
├─ dir-glob@3.0.1
├─ doctrine@2.1.0
├─ dot-prop@5.3.0
├─ eastasianwidth@0.2.0
├─ emoji-regex@8.0.0
├─ error-ex@1.3.2
├─ es-set-tostringtag@2.0.1
├─ es-to-primitive@1.2.1
├─ esbuild@0.16.17
├─ escape-string-regexp@4.0.0
├─ eslint-import-resolver-node@0.3.7
├─ eslint-module-utils@2.7.4
├─ eslint-plugin-import@2.27.5
├─ eslint-scope@7.1.1
├─ eslint@8.34.0
├─ esquery@1.4.2
├─ estraverse@5.3.0
├─ estree-walker@2.0.2
├─ fast-glob@3.2.12
├─ fast-json-stable-stringify@2.1.0
├─ fast-levenshtein@2.0.6
├─ fastq@1.15.0
├─ file-entry-cache@6.0.1
├─ fill-range@7.0.1
├─ flat-cache@3.0.4
├─ flatted@3.2.7
├─ foreground-child@2.0.0
├─ fs-extra@11.1.0
├─ fs.realpath@1.0.0
├─ function.prototype.name@1.1.5
├─ get-stream@6.0.1
├─ get-symbol-description@1.0.0
├─ git-raw-commits@2.0.11
├─ glob-parent@6.0.2
├─ glob@7.2.3
├─ global-dirs@0.1.1
├─ globalthis@1.0.3
├─ globby@11.1.0
├─ graceful-fs@4.2.10
├─ hard-rejection@2.1.0
├─ has-bigints@1.0.2
├─ has-flag@4.0.0
├─ has-proto@1.0.1
├─ hosted-git-info@4.1.0
├─ html-escaper@2.0.2
├─ human-signals@2.1.0
├─ husky@8.0.3
├─ imurmurhash@0.1.4
├─ inflight@1.0.6
├─ inherits@2.0.4
├─ ini@1.3.8
├─ internal-slot@1.0.5
├─ is-array-buffer@3.0.1
├─ is-arrayish@0.2.1
├─ is-bigint@1.0.4
├─ is-boolean-object@1.1.2
├─ is-callable@1.2.7
├─ is-date-object@1.0.5
├─ is-extglob@2.1.1
├─ is-negative-zero@2.0.2
├─ is-number-object@1.0.7
├─ is-number@7.0.0
├─ is-obj@2.0.0
├─ is-path-inside@3.0.3
├─ is-plain-obj@1.1.0
├─ is-shared-array-buffer@1.0.2
├─ is-stream@2.0.1
├─ is-string@1.0.7
├─ is-symbol@1.0.4
├─ is-text-path@1.0.1
├─ is-weakref@1.0.2
├─ isexe@2.0.0
├─ istanbul-lib-coverage@3.2.0
├─ istanbul-reports@3.1.5
├─ js-sdsl@4.3.0
├─ js-tokens@4.0.0
├─ json-parse-even-better-errors@2.3.1
├─ json-schema-traverse@0.4.1
├─ json-stable-stringify-without-jsonify@1.0.1
├─ json-stringify-safe@5.0.1
├─ json5@1.0.2
├─ jsonc-parser@3.2.0
├─ jsonfile@6.1.0
├─ jsonparse@1.3.1
├─ JSONStream@1.3.5
├─ kind-of@6.0.3
├─ lilconfig@2.0.6
├─ lines-and-columns@1.2.4
├─ lint-staged@13.1.2
├─ listr2@5.0.7
├─ local-pkg@0.4.3
├─ locate-path@6.0.0
├─ lodash.camelcase@4.3.0
├─ lodash.isfunction@3.0.9
├─ lodash.isplainobject@4.0.6
├─ lodash.kebabcase@4.1.1
├─ lodash.mergewith@4.6.2
├─ lodash.snakecase@4.1.1
├─ lodash.startcase@4.4.0
├─ lodash.uniq@4.5.0
├─ lodash.upperfirst@4.3.1
├─ lodash@4.17.21
├─ log-update@4.0.0
├─ loupe@2.3.6
├─ make-dir@3.1.0
├─ make-error@1.3.6
├─ map-obj@1.0.1
├─ merge2@1.4.1
├─ micromatch@4.0.5
├─ mimic-fn@2.1.0
├─ min-indent@1.0.1
├─ minimist-options@4.1.0
├─ minimist@1.2.8
├─ mlly@1.1.1
├─ ms@2.1.2
├─ nanoid@3.3.4
├─ natural-compare-lite@1.4.0
├─ natural-compare@1.4.0
├─ nock@13.3.0
├─ node-fetch@2.6.9
├─ normalize-package-data@3.0.3
├─ normalize-path@3.0.0
├─ npm-run-path@4.0.1
├─ object.assign@4.1.4
├─ object.values@1.1.6
├─ onetime@5.1.2
├─ optionator@0.9.1
├─ p-limit@4.0.0
├─ p-locate@5.0.0
├─ p-map@4.0.0
├─ p-try@2.2.0
├─ parent-module@1.0.1
├─ path-is-absolute@1.0.1
├─ path-key@3.1.1
├─ path-parse@1.0.7
├─ pathval@1.1.1
├─ pidtree@0.6.0
├─ pkg-types@1.0.2
├─ postcss@8.4.21
├─ pretty-format@27.5.1
├─ propagate@2.0.1
├─ punycode@2.3.0
├─ queue-microtask@1.2.3
├─ quick-lru@4.0.1
├─ react-is@17.0.2
├─ read-pkg-up@7.0.1
├─ read-pkg@5.2.0
├─ readable-stream@3.6.0
├─ redent@3.0.0
├─ regexp.prototype.flags@1.4.3
├─ require-from-string@2.0.2
├─ resolve-global@1.0.0
├─ restore-cursor@3.1.0
├─ reusify@1.0.4
├─ rfdc@1.3.0
├─ rollup@3.17.2
├─ run-parallel@1.2.0
├─ rxjs@7.8.0
├─ safe-buffer@5.2.1
├─ safe-regex-test@1.0.0
├─ shebang-command@2.0.0
├─ shebang-regex@3.0.0
├─ shell-escape@0.2.0
├─ side-channel@1.0.4
├─ siginfo@2.0.0
├─ slash@3.0.0
├─ slice-ansi@5.0.0
├─ source-map-js@1.0.2
├─ source-map-support@0.5.21
├─ source-map@0.6.1
├─ spdx-correct@3.1.1
├─ spdx-exceptions@2.3.0
├─ stackback@0.0.2
├─ string_decoder@1.3.0
├─ string-argv@0.3.1
├─ string.prototype.trimend@1.0.6
├─ string.prototype.trimstart@1.0.6
├─ strip-bom@3.0.0
├─ strip-final-newline@2.0.0
├─ strip-indent@3.0.0
├─ strip-json-comments@3.1.1
├─ strip-literal@1.0.1
├─ supports-preserve-symlinks-flag@1.0.0
├─ test-exclude@6.0.0
├─ text-extensions@1.9.0
├─ text-table@0.2.0
├─ through@2.3.8
├─ tinybench@2.3.1
├─ tinypool@0.3.1
├─ to-regex-range@5.0.1
├─ tr46@0.0.3
├─ trim-newlines@3.0.1
├─ ts-node@10.9.1
├─ tsconfig-paths@3.14.1
├─ tslib@1.14.1
├─ tunnel@0.0.6
├─ type-check@0.4.0
├─ type-detect@4.0.8
├─ type-fest@0.20.2
├─ typed-array-length@1.0.4
├─ typescript@4.9.5
├─ ufo@1.1.0
├─ unbox-primitive@1.0.2
├─ util-deprecate@1.0.2
├─ uuid@8.3.2
├─ v8-compile-cache-lib@3.0.1
├─ v8-to-istanbul@9.1.0
├─ vite-node@0.28.5
├─ webidl-conversions@3.0.1
├─ whatwg-url@5.0.0
├─ which-boxed-primitive@1.0.2
├─ which-typed-array@1.1.9
├─ which@2.0.2
├─ why-is-node-running@2.2.2
├─ word-wrap@1.2.3
├─ yallist@4.0.0
├─ yaml@2.2.1
├─ yargs-parser@20.2.9
├─ yargs@17.7.1
├─ yn@3.1.1
└─ yocto-queue@1.0.0
Done in 9.15s.
```



</details>
<details>
<summary><em>yarn audit</em></summary>

```Shell
yarn audit v1.22.19
0 vulnerabilities found - Packages audited: 531
Done in 0.69s.
```



</details>

</details>

## Changed files
<details>
<summary>Changed 2 files: </summary>

- package.json
- yarn.lock

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)